### PR TITLE
added sync mute option

### DIFF
--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -6,6 +6,7 @@ const defaults = {
     gain_max: 12,
     start_with_windows: true,
     limit_db_gain_to_0: false,
+    sync_mute: true,
     remember_volume: false,
     disable_donate: false,
     audiodg: {

--- a/src/lib/managers/audioSyncManager.js
+++ b/src/lib/managers/audioSyncManager.js
@@ -247,24 +247,26 @@ const runWinAudio = () => {
 
     AudioEvents.on('mute', (status) => {
         // status.new = true or false to indicate mute
-        if (voicemeeterConnection) {
-            for (let [key, value] of systray.internalIdMap) {
-                if (
-                    value.checked &&
-                    (value?.sid?.startsWith('Strip') ||
-                        value?.sid?.startsWith('Bus'))
-                ) {
-                    const tokens = value.sid.split('_');
-                    const type = '';
-                    const isMute = status.new ? 1 : 0;
-                    try {
-                        voicemeeterConnection.setParameter(
-                            tokens[0],
-                            tokens[1],
-                            'Mute',
-                            isMute
-                        );
-                    } catch (e) {}
+        if (isToggleChecked('sync_mute')) {
+            if (voicemeeterConnection) {
+                for (let [key, value] of systray.internalIdMap) {
+                    if (
+                        value.checked &&
+                        (value?.sid?.startsWith('Strip') ||
+                            value?.sid?.startsWith('Bus'))
+                    ) {
+                        const tokens = value.sid.split('_');
+                        const type = '';
+                        const isMute = status.new ? 1 : 0;
+                        try {
+                            voicemeeterConnection.setParameter(
+                                tokens[0],
+                                tokens[1],
+                                'Mute',
+                                isMute
+                            );
+                        } catch (e) {}
+                    }
                 }
             }
         }

--- a/src/lib/strings.js
+++ b/src/lib/strings.js
@@ -106,6 +106,10 @@ const STRING_MENU_ITEMS = {
         t: 'Use Linear Volume Scaling',
         d: '',
     },
+    itemSyncMute: {
+        t: 'Sync mute',
+        d: '',
+    },
     itemRestoreVolume: {
         t: 'Restore Volume At Launch',
         d: '',

--- a/src/menuItems/itemListPatches.js
+++ b/src/menuItems/itemListPatches.js
@@ -1,4 +1,5 @@
 import { itemLimitdBGain } from './settings/itemLimitdBGain';
+import { itemSyncMute } from './settings/itemSyncMute';
 import { itemRestoreVolume } from './patches/itemRestoreVolume';
 import { itemPreventVolumeSpikes } from './patches/itemPreventVolumeSpikes';
 import { itemCrackleFix } from './patches/itemCrackleFix';
@@ -20,6 +21,7 @@ const itemListPatches = (props) => {
             itemStartWithWindows(),
             itemLimitdBGain(),
             itemLinearVolumeScale(),
+            itemSyncMute(),
             { title: '', enabled: false },
             { title: STRING_MENU_ITEMS['itemTitleDriverWorkarounds'] },
             itemRestoreVolume(),

--- a/src/menuItems/settings/itemSyncMute.js
+++ b/src/menuItems/settings/itemSyncMute.js
@@ -1,0 +1,27 @@
+import { STRING_MENU_ITEMS } from '../../lib/strings';
+
+/**
+ * menu entry to sync mute
+ * @param {object} props properties passed to the menu item
+ * @returns
+ */
+const itemSyncMute = (props) => {
+    return {
+        title: STRING_MENU_ITEMS['itemSyncMute'].t,
+        checked: true,
+        sid: 'sync_mute',
+        enabled: true,
+        init: function (checked) {
+            // do nothing
+        },
+        activate: function (checked) {
+            if (checked) {
+                console.log('Syncing mute');
+            } else {
+                console.log('No longer sync mute');
+            }
+        },
+    };
+};
+
+export { itemSyncMute };


### PR DESCRIPTION
## English
I have added an option on whether to sync the mute.
This is for cases where I want to keep the mute toggle when working with multiple volumes.

I have hardly written JavaScript, so it may not be the correct way to write it....

I think it's related to #20.

## 日本語
ミュートを同期するかどうかを選べるオプションを追加しました。
これは、複数のボリュームを操作するときにミュートのトグルの状態を維持したい場合に有効です。

JavaScriptをほとんど書いたことが無いので、これが正しい書き方かどうか分かりません…

#20 に関係していると思います。

![image](https://user-images.githubusercontent.com/40651807/153713198-6c03bf07-06af-4412-9b1b-1d7dd0c96ecf.png)

https://user-images.githubusercontent.com/40651807/153713214-08b054a5-a2ab-4687-b292-919023702506.mp4